### PR TITLE
Version bump for bugfix release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kdump"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Luke Newcomb <newcomb.luke@protonmail.com>"]
 edition = "2021"
 license = "GPL-3.0"


### PR DESCRIPTION
KerbalObjects 4.0.2 was released, so a new version of KDump must be released